### PR TITLE
Adding repository info in pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/alexlafroscia/ember-wc-utils.git"
+  },
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",


### PR DESCRIPTION
Noticed npm isn't linking to the repo - it was advertised in ember weekly :)